### PR TITLE
pexif.fromFile correctly releases file handle.

### DIFF
--- a/pexif.py
+++ b/pexif.py
@@ -972,7 +972,8 @@ class JpegFile:
 
     def fromFile(filename, mode="rw"):
         """Return a new JpegFile object from a given filename."""
-        return JpegFile(open(filename, "rb"), filename=filename, mode=mode)
+        with open(filename, "rb") as f:
+            return JpegFile(f, filename=filename, mode=mode)
     fromFile = staticmethod(fromFile)
 
     def fromString(str, mode="rw"):


### PR DESCRIPTION
I implemented a fix for: http://stackoverflow.com/questions/19574328/how-to-unlock-file-locked-by-pexif

fromFile doesn't release the file handle because of a direct call to open() with no close(). This causes subsequent attempts to use the file, such as with os.rename(), to fail because the file is still locked. I've placed the JpegFile constructor within a with block to automatically close the file after returning the constructed JpegFile object.
