### PR TITLE
Adds DocumentName tag to self.exif.primary, and fixes a couple comment typos

### DIFF
--- a/pexif.py
+++ b/pexif.py
@@ -665,7 +665,7 @@ class IfdExtendedEXIF(IfdData):
         0x9102: ("Image compression mode", "CompressedBitsPerPixel"),
         0xA002: ("Valid image width", "PixelXDimension"),
         0xA003: ("Valid image height", "PixelYDimension"),
-        # D. Tags relatin to User informatio
+        # D. Tags relating to User information
         0x927c: ("Manufacturer notes", "MakerNote"),
         0x9286: ("User comments", "UserComment"),
         # E. Tag relating to related file information


### PR DESCRIPTION
Since I write DocumentName to my images (along with the more common ImageDescription and Usercomment) I thought I'd add it as an option.
