### PR TITLE
Add support for altitude

### DIFF
--- a/pexif.py
+++ b/pexif.py
@@ -1114,11 +1114,9 @@ class JpegFile:
             return (float(deg.num) / deg.den) +  \
                 (1/60.0 * float(min.num) / min.den) + \
                 (1/3600.0 * float(sec.num) / sec.den)
-
         if not self.exif.primary.has_key(GPSIFD):
             raise self.NoSection, "File %s doesn't have a GPS section." % \
                 self.filename
-
 
         gps = self.exif.primary.GPS
         lat = convert(gps.GPSLatitude)
@@ -1137,7 +1135,6 @@ class JpegFile:
             alt = float(alt_rational.num) / alt_rational.den
             if alt_ref == 1:
                alt = -alt
-
 
         return lat, lng, alt
 

--- a/scripts/setgps.py
+++ b/scripts/setgps.py
@@ -2,15 +2,19 @@
 from pexif import JpegFile
 import sys
 
-usage = """Usage: setgps.py filename.jpg lat lng"""
+usage = """Usage: setgps.py filename.jpg lat lng [alt]"""
 
-if len(sys.argv) != 4:
+if len(sys.argv) != 4 and len(sys.argv) != 5:
     print >> sys.stderr, usage
     sys.exit(1)
 
 try:
     ef = JpegFile.fromFile(sys.argv[1])
-    ef.set_geo(float(sys.argv[2]), float(sys.argv[3]))
+    if len(sys.argv) >= 5:
+        alt = float(sys.argv[4])
+    else:
+        alt = None
+    ef.set_geo(float(sys.argv[2]), float(sys.argv[3]), alt)
 except IOError:
     type, value, traceback = sys.exc_info()
     print >> sys.stderr, "Error opening file:", value

--- a/test/test.py
+++ b/test/test.py
@@ -123,7 +123,7 @@ class TestExifFunctions(unittest.TestCase):
             self.assertEqual(attr.Make, "CanonFoo")
             attr["Make"] = "CanonFoo"
             self.assertEqual(attr["Make"], "CanonFoo")
-        
+
     def test_setattr_exist_none(self):
         for test_file, _ in test_data:
             attr = pexif.JpegFile.fromFile(test_file). \
@@ -156,24 +156,26 @@ class TestExifFunctions(unittest.TestCase):
     def test_simple_add_geo(self):
         for test_file, _ in test_data:
             jf = pexif.JpegFile.fromFile(test_file)
-            (lat, lng) = (-37.312312, 45.412321)
-            jf.set_geo(lat, lng)
+            (lat, lng, alt) = (-37.312312, 45.412321, 123.123)
+            jf.set_geo(lat, lng, alt)
             new_file = jf.writeString()
             new = pexif.JpegFile.fromString(new_file)
-            new_lat, new_lng = new.get_geo()
+            new_lat, new_lng, new_alt = new.get_geo()
             self.assertAlmostEqual(lat, new_lat, 6)
             self.assertAlmostEqual(lng, new_lng, 6)
+            self.assertAlmostEqual(alt, new_alt, 6)
 
     def test_simple_add_geo2(self):
         for test_file, _ in test_data:
             jf = pexif.JpegFile.fromFile(test_file)
-            (lat, lng) = (51.522, -1.455)
-            jf.set_geo(lat, lng)
+            (lat, lng, alt) = (51.522, -1.455, -901.2317)
+            jf.set_geo(lat, lng, alt)
             new_file = jf.writeString()
             new = pexif.JpegFile.fromString(new_file)
-            new_lat, new_lng = new.get_geo()
+            new_lat, new_lng, new_alt = new.get_geo()
             self.assertAlmostEqual(lat, new_lat, 6)
             self.assertAlmostEqual(lng, new_lng, 6)
+            self.assertAlmostEqual(alt, new_alt, 6)
 
     def test_simple_add_geo3(self):
         for test_file, _ in test_data:
@@ -182,9 +184,10 @@ class TestExifFunctions(unittest.TestCase):
             jf.set_geo(lat, lng)
             new_file = jf.writeString()
             new = pexif.JpegFile.fromString(new_file)
-            new_lat, new_lng = new.get_geo()
+            new_lat, new_lng, new_alt = new.get_geo()
             self.assertAlmostEqual(lat, new_lat, 6)
             self.assertAlmostEqual(lng, new_lng, 6)
+            self.assertEqual(new_alt, None)
 
     def test_get_geo(self):
         jf = pexif.JpegFile.fromFile(DEFAULT_TESTFILE)
@@ -200,7 +203,7 @@ class TestExifFunctions(unittest.TestCase):
         # exif doesn't exist
         jf = pexif.JpegFile.fromFile(NONEXIST_TESTFILE, mode="ro")
         self.assertRaises(AttributeError, test_get)
-        
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull requests allows set_geo and get_geo to set/get the GPSAltitude tag as well at the lat/lng. 

Unfortunately, this is not backwards compatible, because get_geo now returns a 3-tuple instead of a 2-tuple. The line `lat, lng = my_file.get_geo()` will fail with "ValueError: too many values to unpack". Instead, one should use `lat, lng, alt = my_file.get_geo()`. 

I'll leave it up to the pexif maintainer(s) whether it's worth including this in the project or not. In any case, thanks for sharing pexif; it made my life easier today. 
